### PR TITLE
Adding cmake support and optional zlib/bzip support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@
 *.exe
 *.out
 *.app
+.idea/
+cmake-*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.0)
+project(kseqcpp)
+
+set(CMAKE_CXX_STANDARD 11)
+
+find_package(ZLIB REQUIRED)
+if (ZLIB_FOUND)
+    add_definitions(-DHAVE_ZLIB)
+    include_directories(${ZLIB_INCLUDE_DIRS})
+endif()
+
+find_package(BZip2 REQUIRED)
+if (BZIP2_FOUND)
+    add_definitions(-DHAVE_BZIP2)
+    include_directories(${BZIP2_INCLUDE_DIRS})
+endif()
+
+set(SOURCE_FILES test.cpp kseq.hpp)
+
+add_executable(kseq ${SOURCE_FILES})
+
+target_link_libraries (kseq ${ZLIB_LIBRARIES} ${BZIP2_LIBRARIES})


### PR DESCRIPTION
Determine the availability of zlib/bzip2 from the CMakeLists.txt or compiler options instead of forcing it with `#define HAVE_BZIP2 1` and `#define HAVE_ZLIB  1`